### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/MBG-ICST-APPMOD/4d274640-ba94-4a20-aa75-691eef143158/0c30043f-08c6-4a68-91af-064731eb5615/_apis/work/boardbadge/d41978a5-fc88-41e7-b268-70be054cb412)](https://dev.azure.com/MBG-ICST-APPMOD/4d274640-ba94-4a20-aa75-691eef143158/_boards/board/t/0c30043f-08c6-4a68-91af-064731eb5615/Microsoft.RequirementCategory)
 # hello-world
 what else needs to be said?
 hmmm


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#53](https://dev.azure.com/MBG-ICST-APPMOD/4d274640-ba94-4a20-aa75-691eef143158/_workitems/edit/53). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.